### PR TITLE
patch(dice): dice work now! Also added some new features.

### DIFF
--- a/BOT_COMMANDS.md
+++ b/BOT_COMMANDS.md
@@ -11,3 +11,5 @@
 `fortune - get a random fortune message`
 
 `game - set bots game title`
+
+`roll - roll some dice! (try roll 2d10)`

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "./node_modules/.bin/gulp watch",
     "start": "node _build",
-    "test": "./node_modules/.bin/gulp test"
+    "test": "./node_modules/.bin/gulp test",
+    "mocha": "mocha test/**/*.spec.js --compilers js:babel-register --watch --growl --recursive"
   },
   "bin": "_build/index.js",
   "repository": {
@@ -38,12 +39,15 @@
     "node-opus": "^0.1.11",
     "node-schedule": "^0.6.0",
     "random-js": "^1.0.8",
-    "sifter": "^0.4.5"
+    "request": "^2.67.0",
+    "sifter": "^0.4.5",
+    "xregexp": "^3.0.0"
   },
   "devDependencies": {
     "babel": "^6.3.26",
     "babel-core": "^6.3.26",
     "babel-preset-es2015": "^6.3.13",
+    "babel-register": "^6.4.3",
     "del": "^2.2.0",
     "eslint-config-standard": "^4.4.0",
     "eslint-plugin-standard": "^1.3.1",

--- a/src/index.js
+++ b/src/index.js
@@ -142,7 +142,7 @@ const onMessage = function (user, userID, channelID, message, rawEvent) {
         'xkcd            - get todays xkcd comic',
         'fortune         - get a random fortune message',
         'game            - set bots game title',
-        'roll            - roll some dice'
+        'roll            - roll some dice! (try roll 2d10)'
       ].join('\n')
     })
   }

--- a/src/modules/dice.js
+++ b/src/modules/dice.js
@@ -1,27 +1,82 @@
 'use strict'
 
 import capitalize from './utils/capitalize'
+import x from 'xregexp'
+x.install('natives')
 
-export default {
+const regex = (template) => x(String.raw(template), 'x')
+module.exports = {
   names: ['roll', 'dice'],
   onMessage: function (bot, user, userID, channelID, message, rawEvent, {random}) {
-    const findRollStatement = (search) => search.match(/((\d{0,4})d(\d{0,4}))/)
-    const rollMessage = message.split(' ').slice(2)[0]
-    const rollStatement = findRollStatement(rollMessage)
-    const numDice = rollStatement[2]
-    const sidesPerDie = rollStatement[3]
+    const rollMatches = search => {
+      return regex`
+      (
+        (?<numDice> \d{0,4})
+        d
+        (?<sidesPerDie> \d{0,4})
+      )
+      \s*
+      (?<afterMath>\+\s*\d{0,4})?
+      (?:(?<successSign>[\<\>\=])(?<successThreshold>\d*)*)*`
+      .exec(search)
+    }
+    const rollMessage = message.split(' ').slice(1)[0]
+    const matches = rollMatches(rollMessage)
+    const { numDice, sidesPerDie, afterMath, successSign, successThreshold, input: fullQuery } = matches
     const result = random.dice(+sidesPerDie, +numDice)
-    const accumulatedDiceTotal = result.length ? result.reduce((acc, die) => acc + die) : null
+    const actualAfterMath = +afterMath ? +afterMath : 0
+    const accumulatedDiceTotal = result.length ? result.reduce((acc, die) => acc + die) : 0
+    const fullTotal = actualAfterMath + accumulatedDiceTotal
+
+    // bad syntax..
     if (!accumulatedDiceTotal) {
       bot.sendMessage({
         to: channelID,
-        message: `${capitalize(user.username)} doesn't understand how rolling dice works.. ${rollMessage} is not a valid dice roll!`
+        message: `${capitalize(user)} doesn't understand how rolling dice works.. ${fullQuery} is not a valid dice roll!`
       })
       return
     }
+
+    function pluralizeSuccesses (num) {
+      if (+num === 0) {
+        return '0 Successes'
+      }
+      if (+num === 1) {
+        return '1 Success'
+      }
+      return `${num} Successes`
+    }
+
+    function numSuccesses (candidates, sign, threshold) {
+      const comparators = {
+        '<': d => +d <= +threshold,
+        '>': d => +d >= +threshold,
+        '=': d => +d === +threshold
+      }
+      return pluralizeSuccesses(candidates.filter(comparators[sign]).length)
+    }
+
+    // The juicy bits
+    function constructMessage () {
+      let constructedMessage = []
+      constructedMessage.push(`${capitalize(user)} rolled ${fullQuery}!`) // preamble
+      constructedMessage.push(`( ${result.join(' + ')} )`)// main return
+      if (actualAfterMath) {
+        constructedMessage.push(`+ ${actualAfterMath}`)
+        constructedMessage.push(`= ${fullTotal}`) // cut out early when there's aftermath
+        return constructedMessage
+      }
+      if (successSign && successThreshold) {
+        constructedMessage.push(`= ${numSuccesses(result, successSign, successThreshold)}`)
+        return constructedMessage
+      }
+      constructedMessage.push(`= ${fullTotal}`)
+      return constructedMessage
+    }
+
     bot.sendMessage({
       to: channelID,
-      message: `${capitalize(user.username)} rolled ${rollStatement[1]}! ${result.join(' + ')} = ${accumulatedDiceTotal}`
+      message: constructMessage().join(' ')
     })
   }
 }

--- a/test/modules/dice.spec.js
+++ b/test/modules/dice.spec.js
@@ -7,7 +7,7 @@ const it = global.it
 import assert from 'assert'
 import Random from 'random-js'
 import sinon from 'sinon'
-const random = new Random(Random.engines.mt19937().autoSeed())
+const random = new Random(Random.engines.mt19937().seed('lol'))
 const roll = dice.onMessage
 
 describe('Roll Dice', () => {
@@ -19,9 +19,8 @@ describe('Roll Dice', () => {
     const bot = {
       sendMessage: spy
     }
-    const rollMessage = `!bot ${rollCommand} ${inputMessage}`
-
-    roll(bot, {username}, '', '', rollMessage, '', dependencies)
+    const rollMessage = `${rollCommand} ${inputMessage}`
+    roll(bot, username, '', '', rollMessage, '', dependencies)
     const {message, channel} = spy.getCall(0).args[0]
     return {message, channel}
   }
@@ -35,15 +34,15 @@ describe('Roll Dice', () => {
 
   it(`rolls a number of sided dice.`, () => {
     const {message: actual} = roller('kingles', '2d10')
-    const expected = /Kingles rolled 2d10! \d* \+ \d* \= \d*/
+    const expected = 'Kingles rolled 2d10! ( 4 + 1 ) = 5'
 
-    assert.ok(expected.test(actual))
+    assert.equal(actual, expected)
   })
 
   it(`rolls a large number of small sided dice.`, () => {
     const numDice = 1000
     const {message: actual} = roller('kingles', `${numDice}d10`)
-    const expected = new RegExp(`Kingles rolled ${numDice}d10! \\d*( \\+ \\d*){${+numDice - 1}} \\= \\d*`)
+    const expected = new RegExp(String.raw`Kingles rolled ${numDice}d10! \( \d*( \+ \d*){${+numDice - 1}} \) \= \d*`) // not testing deterministically because fuck 1000 dice. Suffice to say it works.
 
     assert.ok(expected.test(actual))
   })
@@ -52,15 +51,43 @@ describe('Roll Dice', () => {
     const numDice = 4
     const numSides = 100
     const {message: actual} = roller('kingles', `${numDice}d${numSides}`)
-    const expected = new RegExp(`Kingles rolled ${numDice}d${numSides}! \\d*( \\+ \\d*){${+numDice - 1}} \\= \\d*`)
+    const expected = 'Kingles rolled 4d100! ( 5 + 91 + 60 + 13 ) = 169'
 
-    assert.ok(expected.test(actual))
+    assert.equal(actual, expected)
   })
 
   it(`ridicules the user when syntax is invalid`, () => {
     const {message: actual} = roller('kingles', 'ads')
-    const expected = /Kingles doesn't understand how rolling dice works.. ads is not a valid dice roll!/
+    const expected = 'Kingles doesn\'t understand how rolling dice works.. ads is not a valid dice roll!'
 
-    assert.ok(expected.test(actual))
+    assert.equal(actual, expected)
+  })
+
+  it(`handles addition at the end of a roll`, () => {
+    const {message: actual} = roller('kingles', '3d10+5')
+    const expected = 'Kingles rolled 3d10+5! ( 8 + 10 + 1 ) + 5 = 24'
+
+    assert.equal(actual, expected)
+  })
+
+  it(`handles counting successes at or more than a given value`, () => {
+    const {message: actual} = roller('kingles', '4d10>8')
+    const expected = 'Kingles rolled 4d10>8! ( 1 + 3 + 8 + 7 ) = 1 Success'
+
+    assert.equal(actual, expected)
+  })
+
+  it('handles counting successes less than a given value', () => {
+    const {message: actual} = roller('kingles', '4d10<8')
+    const expected = 'Kingles rolled 4d10<8! ( 4 + 10 + 2 + 5 ) = 3 Successes'
+
+    assert.equal(actual, expected)
+  })
+
+  it('handles counting succcesses at exactly a given value', () => {
+    const {message: actual} = roller('kingles', '4d10=9')
+    const expected = 'Kingles rolled 4d10=9! ( 2 + 7 + 3 + 9 ) = 1 Success'
+
+    assert.equal(actual, expected)
   })
 })


### PR DESCRIPTION
## Release Notes
- `!bot roll [x]d[y]` rolls `x` dice of `y` sides and displays the roll and sum
- `!bot roll [x]d[y]+[z]` rolls `x` dice of `y` sides and adds `z` before displaying the roll and sum 
- `!bot roll [x]d[y]>z` rolls `x` dice of `y` sides and displays the roll as well as the number of rolls that equaled or were more than `z`
- `!bot roll [x]d[y]<z` rolls `x` dice of `y` sides and displays the roll as well as the number of rolls that equaled or were less than `z`
- `!bot roll [x]d[y]=z` rolls `x` dice of `y` sides and displays the roll as well as the number of rolls that were exactly `z`
## Developer Notes
- dice tests now use a consistent seed to aid testing.
- 100% tested for current features
- fixed bad assumptions about how onMessage arguments worked for dice tests
- played with the logic for constructing the dice message
